### PR TITLE
Implementation of identifications for requests

### DIFF
--- a/src/Exceptions/IdentificationDataValidation.php
+++ b/src/Exceptions/IdentificationDataValidation.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wearesho\Pvbki\Exceptions;
+
+/**
+ * Class IdentificationDataValidation
+ * @package Wearesho\Pvbki\Exceptions
+ */
+class IdentificationDataValidation extends \InvalidArgumentException
+{
+    /** @var string */
+    protected $data;
+
+    public function __construct($data, int $code = 0, \Throwable $previous = null)
+    {
+        $this->data = $data;
+
+        parent::__construct("Validation failed for data: " . $data, $code, $previous);
+    }
+
+    public function getData(): string
+    {
+        return $this->data;
+    }
+}

--- a/src/Identifications/Complex.php
+++ b/src/Identifications/Complex.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Wearesho\Pvbki\Identifications;
+
+use Carbon\Carbon;
+use Wearesho\Pvbki\Exceptions\IdentificationDataValidation;
+
+/**
+ * Class Complex
+ * @package Wearesho\Pvbki\Identifications
+ */
+class Complex implements SubjectInterface
+{
+    use SubjectTrait;
+
+    public function __construct(string $name, string $surname, \DateTimeInterface $birthDate)
+    {
+        if (empty($name)) {
+            throw new IdentificationDataValidation($name);
+        }
+
+        if (empty($surname)) {
+            throw new IdentificationDataValidation($surname);
+        }
+
+        $this->id = $name . $surname . Carbon::instance($birthDate)->toDateString();
+    }
+}

--- a/src/Identifications/Complex.php
+++ b/src/Identifications/Complex.php
@@ -15,12 +15,8 @@ class Complex implements SubjectInterface
 
     public function __construct(string $name, string $surname, \DateTimeInterface $birthDate)
     {
-        if (empty($name)) {
-            throw new IdentificationDataValidation($name);
-        }
-
-        if (empty($surname)) {
-            throw new IdentificationDataValidation($surname);
+        if (empty($name) || empty($surname)) {
+            throw new IdentificationDataValidation("Name: {$name}; Surname: {$surname};");
         }
 
         $this->id = $name . $surname . Carbon::instance($birthDate)->toDateString();

--- a/src/Identifications/Drfo.php
+++ b/src/Identifications/Drfo.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Wearesho\Pvbki\Identifications;
+
+use Wearesho\Pvbki\Exceptions\IdentificationDataValidation;
+
+/**
+ * Class Drfo
+ * @package Wearesho\Pvbki\Identifications
+ */
+class Drfo implements SubjectInterface
+{
+    use SubjectTrait;
+
+    public function __construct(string $number)
+    {
+        if (!preg_match('/^[0-9]{10}$/', $number)) {
+            throw new IdentificationDataValidation($number);
+        }
+
+        $this->id = $number;
+    }
+}

--- a/src/Identifications/Okpo.php
+++ b/src/Identifications/Okpo.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Wearesho\Pvbki\Identifications;
+
+use Wearesho\Pvbki\Exceptions\IdentificationDataValidation;
+
+/**
+ * Class Okpo
+ * @package Wearesho\Pvbki\Identifications
+ */
+class Okpo implements SubjectInterface
+{
+    use SubjectTrait;
+
+    public function __construct(string $number)
+    {
+        if (!preg_match('/^[0-9]{8}$/', $number)) {
+            throw new IdentificationDataValidation($number);
+        }
+
+        $this->id = $number;
+    }
+}

--- a/src/Identifications/Passport.php
+++ b/src/Identifications/Passport.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wearesho\Pvbki\Identifications;
+
+use Wearesho\Pvbki\Exceptions\IdentificationDataValidation;
+
+/**
+ * Class Passport
+ * @package Wearesho\Pvbki\Identifications
+ */
+class Passport implements SubjectInterface
+{
+    use SubjectTrait;
+
+    public function __construct(string $series, string $number)
+    {
+        $passportData = $series . $number;
+
+        if (!preg_match('/^[ыЫа-яА-Яa-zA-ZіІєЄґҐїЇ]{2}\d{6}$/u', $series . $number)) {
+            throw new IdentificationDataValidation($passportData);
+        }
+
+        $this->id = $passportData;
+    }
+}

--- a/src/Identifications/SubjectInterface.php
+++ b/src/Identifications/SubjectInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wearesho\Pvbki\Identifications;
+
+/**
+ * Interface SubjectInterface
+ * @package Wearesho\Pvbki\Identifications
+ */
+interface SubjectInterface
+{
+    /**
+     * Must return well formatted subject id
+     *
+     * @return string
+     */
+    public function getId(): string;
+}

--- a/src/Identifications/SubjectTrait.php
+++ b/src/Identifications/SubjectTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Wearesho\Pvbki\Identifications;
+
+/**
+ * Class Subject
+ * @package Wearesho\Pvbki\Identifications
+ */
+trait SubjectTrait
+{
+    /** @var string */
+    protected $id;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/tests/Unit/Exceptions/IdentificationDataValidationTest.php
+++ b/tests/Unit/Exceptions/IdentificationDataValidationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Wearesho\Pvbki\Tests\Unit\Exceptions;
+
+use Wearesho\Pvbki\Exceptions\IdentificationDataValidation;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class IdentificationDataValidationTest
+ * @package Wearesho\Pvbki\Tests\Unit\Exceptions
+ * @coversDefaultClass IdentificationDataValidation
+ * @internal
+ */
+class IdentificationDataValidationTest extends TestCase
+{
+    public function testGetData(): void
+    {
+        $data = 'some data';
+        $exception = new IdentificationDataValidation($data);
+
+        $this->assertEquals($data, $exception->getData());
+    }
+}

--- a/tests/Unit/IdentificationsTest.php
+++ b/tests/Unit/IdentificationsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Wearesho\Pvbki\Tests\Unit;
+
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+use Wearesho\Pvbki\Identifications;
+
+/**
+ * Class IdentificationsTest
+ * @package Wearesho\Pvbki\Tests\Unit
+ */
+class IdentificationsTest extends TestCase
+{
+    public function testCorrectPassport(): void
+    {
+        $series = 'AK';
+        $number = '123456';
+        $passport = new Identifications\Passport($series, $number);
+
+        $this->assertEquals($series . $number, $passport->getId());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Validation failed for data: seriesnumber
+     */
+    public function testInvalidPassport(): void
+    {
+        new Identifications\Passport('series', 'number');
+    }
+
+    public function testCorrectOkpo(): void
+    {
+        $number = '12345678';
+        $okpo = new Identifications\Okpo($number);
+
+        $this->assertEquals($number, $okpo->getId());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Validation failed for data: 123456
+     */
+    public function testInvalidOkpo(): void
+    {
+        new Identifications\Okpo('123456');
+    }
+
+    public function testCorrectDrfo(): void
+    {
+        $number = '1234567890';
+        $drfo = new Identifications\Drfo($number);
+
+        $this->assertEquals($number, $drfo->getId());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Validation failed for data: 123456
+     */
+    public function testInvalidDrfo(): void
+    {
+        new Identifications\Drfo('12345678');
+    }
+
+    public function testCorrectComplex(): void
+    {
+        $name = 'Name';
+        $surname = 'Surname';
+        $date = Carbon::parse('1998-03-12');
+        $complex = new Identifications\Complex($name, $surname, $date);
+
+        $this->assertEquals(
+            $name . $surname . $date->toDateString(),
+            $complex->getId()
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Validation failed for data:
+     */
+    public function testInvalidNameComplex(): void
+    {
+        new Identifications\Complex('', 'Surname', Carbon::now());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Validation failed for data:
+     */
+    public function testInvalidSurnameComplex(): void
+    {
+        new Identifications\Complex('Name', '', Carbon::now());
+    }
+}

--- a/tests/Unit/IdentificationsTest.php
+++ b/tests/Unit/IdentificationsTest.php
@@ -88,7 +88,7 @@ class IdentificationsTest extends TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Validation failed for data:
+     * @expectedExceptionMessage Validation failed for data: Name: Name; Surname:
      */
     public function testInvalidSurnameComplex(): void
     {


### PR DESCRIPTION
As say in docs:

> Код ДРФО физического лица состоит из 10 цифр, а код ОКПО юридического лица из 8 цифр. Паспорт должен содержать две кириллические буквы и 6 цифр с произвольным разделителем или без такового. Сложный ключ состоит из произвольного (имя, фамилия без пробелов) набора символов и суффикса из 8 цифр указывающих дату рождения субъекта в формате DDMMYYYY. Если методу не удаётся распознать тип идентификатора, генерируется исключение. После определения типа идентификатора производится поиск субъекта. Если субъект отсутствует в базе данных ПВБКИ, генерируется пустой отчёт