### PR TITLE
Scoring element

### DIFF
--- a/src/Elements/Scoring.php
+++ b/src/Elements/Scoring.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Wearesho\Pvbki\Elements;
+
+use Wearesho\Pvbki\Infrastructure\Element;
+
+/**
+ * Class Scoring
+ * @package Wearesho\Pvbki\Elements
+ */
+class Scoring extends Element
+{
+    public const ROOT = 'Scoring';
+    public const DEGREE = 'Degree';
+    public const SCORE = 'Score';
+    public const FAULT_CHANCE = 'FaultChance';
+    public const ADVERSE = 'Adverse';
+
+    /** @var string|null */
+    protected $degree;
+
+    /** @var int|null */
+    protected $score;
+
+    /** @var float|null */
+    protected $faultChance;
+
+    /** @var string|null */
+    protected $adverse;
+
+    public function __construct(?string $degree, ?int $score, ?float $faultChance, ?string $adverse)
+    {
+        $this->degree = $degree;
+        $this->score = $score;
+        $this->faultChance = $faultChance;
+        $this->adverse = $adverse;
+    }
+
+    public function getDegree(): ?string
+    {
+        return $this->degree;
+    }
+
+    public function getScore(): ?int
+    {
+        return $this->score;
+    }
+
+    public function getFaultChance(): ?float
+    {
+        return $this->faultChance;
+    }
+
+    public function getAdverse(): ?string
+    {
+        return $this->adverse;
+    }
+}

--- a/tests/Unit/Elements/ScoringTest.php
+++ b/tests/Unit/Elements/ScoringTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Wearesho\Pvbki\Tests\Unit\Elements;
+
+use Wearesho\Pvbki\Elements\Scoring;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ScoringTest
+ * @package Wearesho\Pvbki\Tests\Unit\Elements
+ * @coversDefaultClass Scoring
+ * @internal
+ */
+class ScoringTest extends TestCase
+{
+    protected const DEGREE = 'degree';
+    protected const SCORE = 1000;
+    protected const FAULT_CHANCE = 12.34;
+    protected const ADVERSE = 'adverse';
+
+    /** @var Scoring */
+    protected $fakeScoring;
+
+    protected function setUp(): void
+    {
+        $this->fakeScoring = new Scoring(
+            static::DEGREE,
+            static::SCORE,
+            static::FAULT_CHANCE,
+            static::ADVERSE
+        );
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $this->assertArraySubset(
+            [
+                'degree' => static::DEGREE,
+                'score' => static::SCORE,
+                'faultChance' => static::FAULT_CHANCE,
+                'adverse' => static::ADVERSE,
+            ],
+            $this->fakeScoring->jsonSerialize()
+        );
+    }
+
+    public function testGetFaultChance(): void
+    {
+        $this->assertEquals(static::FAULT_CHANCE, $this->fakeScoring->getFaultChance());
+    }
+
+    public function testGetDegree(): void
+    {
+        $this->assertEquals(static::DEGREE, $this->fakeScoring->getDegree());
+    }
+
+    public function testGetScore(): void
+    {
+        $this->assertEquals(static::SCORE, $this->fakeScoring->getScore());
+    }
+
+    public function testGetAdverse(): void
+    {
+        $this->assertEquals(static::ADVERSE, $this->fakeScoring->getAdverse());
+    }
+}


### PR DESCRIPTION
From docs: Score element represents in xsd schemas:

```xml
<xs:element name="Scoring">
<xs:complexType>
<xs:sequence>
<xs:element minOccurs="0" name="Degree">
<xs:simpleType>
<xs:restriction base="xs:string">
<xs:maxLength value="4"/>
</xs:restriction>
</xs:simpleType>
</xs:element>
<xs:element minOccurs="0" name="Score" type="xs:int"/>
<xs:element minOccurs="0" name="FaultChance" type="xs:decimal"/>
<xs:element minOccurs="0" name="Adverse">
<xs:simpleType>
<xs:restriction base="xs:string">
<xs:maxLength value="512"/>
</xs:restriction>
</xs:simpleType>
</xs:element>
</xs:sequence>
</xs:complexType>
</xs:element>
```

Only one Score element can be in report.